### PR TITLE
fixed display of value expressions

### DIFF
--- a/midscribe-core/src/main/java/com/evolveum/midscribe/generator/ProcessorUtils.java
+++ b/midscribe-core/src/main/java/com/evolveum/midscribe/generator/ProcessorUtils.java
@@ -81,8 +81,7 @@ public class ProcessorUtils {
         }
 
         if (object instanceof RawType) {
-            // todo fix this it's failing to parse and remove condition
-            return null;
+            return ((RawType) object).extractString();
         }
 
         PrismContext prismContext = context.getStore().getPrismContext();

--- a/midscribe-core/src/main/resources/template/expression.vm
+++ b/midscribe-core/src/main/resources/template/expression.vm
@@ -32,7 +32,7 @@ $!utils.stripIndent($expression.getDocumentation())
 #set($value = $expression.getExpressionEvaluator().get(0).getValue())
 
 [indent=0,subs="verbatim,attributes",role="primary"]
-.${value.getClass().getSimpleName().replaceFirst("ExpressionEvaluatorType", "")}
+.${value.getClass().getSimpleName().replaceFirst("ExpressionEvaluatorType", "").replaceFirst("RawType", "Value")}
 ----
 $!value.getDescription()
 


### PR DESCRIPTION
if an expression contains a constant value the rendering was not correct. This has been improved
and the tab name is now "Value" instead of "RawType"